### PR TITLE
Add simple personalized diet plan site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # codextrial
+
+This repository contains a simple Flask web application that generates a personalized diet plan.
+
+## Running the app
+
+1. Install dependencies:
+   ```bash
+   pip install Flask
+   ```
+2. Start the development server:
+   ```bash
+   python app.py
+   ```
+3. Open your web browser and go to `http://localhost:5000` to view the form and generate your diet plan.
+
+The generated plan is for general informational purposes only and should not be considered medical advice.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+from flask import Flask, render_template, request
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    diet_plan = None
+    if request.method == 'POST':
+        name = request.form.get('name', 'User')
+        age = int(request.form.get('age', 0))
+        gender = request.form.get('gender', 'other')
+        weight = float(request.form.get('weight', 0))
+        height = float(request.form.get('height', 0))
+        goal = request.form.get('goal', 'maintain')
+
+        # Simple Basal Metabolic Rate (BMR) calculation using Mifflin-St Jeor Equation
+        if gender == 'male':
+            bmr = 10 * weight + 6.25 * height - 5 * age + 5
+        elif gender == 'female':
+            bmr = 10 * weight + 6.25 * height - 5 * age - 161
+        else:
+            bmr = 10 * weight + 6.25 * height - 5 * age
+
+        # Adjust calories based on goal
+        if goal == 'lose':
+            calories = bmr - 500
+        elif goal == 'gain':
+            calories = bmr + 500
+        else:
+            calories = bmr
+
+        # Simple diet plan output
+        diet_plan = {
+            'name': name,
+            'calories': round(calories),
+            'meals': [
+                {'meal': 'Breakfast', 'details': 'Protein + Complex Carbs + Fruit'},
+                {'meal': 'Lunch', 'details': 'Lean Protein + Vegetables + Whole Grain'},
+                {'meal': 'Snack', 'details': 'Nuts or Yogurt'},
+                {'meal': 'Dinner', 'details': 'Protein + Vegetables + Healthy Fats'}
+            ]
+        }
+
+    return render_template('index.html', diet_plan=diet_plan)
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0')

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Personalized Diet Plan</title>
+</head>
+<body>
+    <h1>Personalized Diet Plan Generator</h1>
+    <form method="post">
+        <label>Name: <input type="text" name="name"></label><br>
+        <label>Age: <input type="number" name="age" required></label><br>
+        <label>Gender: 
+            <select name="gender">
+                <option value="male">Male</option>
+                <option value="female">Female</option>
+                <option value="other">Other</option>
+            </select>
+        </label><br>
+        <label>Weight (kg): <input type="number" step="0.1" name="weight" required></label><br>
+        <label>Height (cm): <input type="number" step="0.1" name="height" required></label><br>
+        <label>Goal:
+            <select name="goal">
+                <option value="maintain">Maintain weight</option>
+                <option value="lose">Lose weight</option>
+                <option value="gain">Gain weight</option>
+            </select>
+        </label><br>
+        <button type="submit">Generate Plan</button>
+    </form>
+
+    {% if diet_plan %}
+        <h2>Hi {{ diet_plan.name }}, your estimated daily calories: {{ diet_plan.calories }}</h2>
+        <ul>
+            {% for meal in diet_plan.meals %}
+                <li><strong>{{ meal.meal }}:</strong> {{ meal.details }}</li>
+            {% endfor %}
+        </ul>
+        <p><em>This plan is for general informational purposes only and is not medical advice. Consult a healthcare professional for personalized recommendations.</em></p>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `app.py` with a Flask web server
- add HTML template to gather basic info and show calories plus a sample diet
- document running the app in `README.md`

## Testing
- `python -m py_compile app.py`
- `pip install Flask`
- `python app.py` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_6862768a2c6c832a92e5735e7c36bb33